### PR TITLE
Ajout des proto gRPC pour le SDK Python

### DIFF
--- a/.protolint.yaml
+++ b/.protolint.yaml
@@ -16,6 +16,7 @@ lint:
     # The specific directories to exclude.
     exclude:
       - proto/google
+      - proto/validate
 
   # Linter rules.
   # Run `protolint list` to see all available rules.

--- a/README.md
+++ b/README.md
@@ -79,3 +79,8 @@ When using "vscode-proto3" extention in VS Code, add the following to the '.vsco
   }
 }
 ```
+## Optionals
+how to select only specific proto, use `--path` args
+```sh
+ buf generate proto --template service-apis/proto/buf.gen.py.yaml -o gen --path service-apis/proto/digitalkin/kin --path service-apis/proto/google
+```

--- a/proto/buf.gen.py.yaml
+++ b/proto/buf.gen.py.yaml
@@ -1,0 +1,14 @@
+# buf.gen.py.yaml
+
+version: v1
+managed:
+  enabled: true
+  optimize_for: CODE_SIZE
+
+plugins:
+  - plugin: buf.build/protocolbuffers/python:v21.7
+    out: .
+    opt:
+      - pyi_out=true
+  - plugin: buf.build/grpc/python:v1.62.0
+    out: .

--- a/proto/digitalkin/module/v1/information.proto
+++ b/proto/digitalkin/module/v1/information.proto
@@ -1,0 +1,20 @@
+// Copyright 2024 DigitalKin Inc.
+//
+// Licensed under the GNU General Public License, Version 3.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.gnu.org/licenses/gpl-3.0.html
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+syntax = "proto3";
+
+package digitalkin.module.v1;
+
+import "validate/validate.proto";

--- a/proto/digitalkin/module/v1/information.proto
+++ b/proto/digitalkin/module/v1/information.proto
@@ -17,4 +17,83 @@ syntax = "proto3";
 
 package digitalkin.module.v1;
 
+import "google/protobuf/struct.proto";
 import "validate/validate.proto";
+
+// GetModuleInputRequest
+//
+// Fields:
+//
+// - module_id: Database ID of the Module to get input schema
+// - llm_format: Define if the input schema should be in LLM format or raw pydantic format
+message GetModuleInputRequest {
+    // module_id: Database ID of the Module to get input schema
+    string module_id = 1 [(validate.rules).string = { min_len: 1, prefix: "modules:" }];
+    // llm_format: Define if the input schema should be in LLM format or raw pydantic format
+    bool llm_format = 2;
+}
+
+// GetModuleOutputRequest
+//
+// Fields:
+//
+// - module_id: Database ID of the Module to get output schema
+// - llm_format: Define if the output schema should be in LLM format or raw pydantic format
+message GetModuleOutputRequest {
+    // module_id: Database ID of the Module to get output schema
+    string module_id = 1 [(validate.rules).string = { min_len: 1, prefix: "modules:" }];
+    // llm_format: Define if the output schema should be in LLM format or raw pydantic format
+    bool llm_format = 2;
+}
+
+// GetModuleSetupRequest
+//
+// Fields:
+//
+// - module_id: Database ID of the Module to get output schema
+// - llm_format: Define if the output schema should be in LLM format or raw pydantic format
+message GetModuleSetupRequest {
+    // module_id: Database ID of the Module to get output schema
+    string module_id = 1 [(validate.rules).string = { min_len: 1, prefix: "modules:" }];
+    // llm_format: Define if the output schema should be in LLM format or raw pydantic format
+    bool llm_format = 2;
+}
+
+// GetModuleInputResponse
+//
+// Returns:
+//
+// - success: Flag to indicate if the input schema request was successful
+// - input_schema: Input schema of the Module
+message GetModuleInputResponse {
+    // success: Flag to indicate if the input schema request was successful
+    bool success = 1;
+    // input_schema: Input schema of the Module
+    google.protobuf.Struct input_schema = 2 [(validate.rules).any = { required: true }];
+}
+
+// GetModuleOutputResponse
+//
+// Returns:
+//
+// - success: Flag to indicate if the input schema request was successful
+// - output_schema: Output schema of the Module
+message GetModuleOutputResponse {
+    // success: Flag to indicate if the output schema request was successful
+    bool success = 1;
+    // output_schema: Output schema of the Module
+    google.protobuf.Struct output_schema = 2 [(validate.rules).any = { required: true }];
+}
+
+// GetModuleSetupResponse
+//
+// Returns:
+//
+// - success: Flag to indicate if the input schema request was successful
+// - setup_schema: Setup schema of the Module
+message GetModuleSetupResponse {
+    // success: Flag to indicate if the setup schema request was successful
+    bool success = 1;
+    // setup_schema: Setup schema of the Module
+    google.protobuf.Struct setup_schema = 2 [(validate.rules).any = { required: true }];
+}

--- a/proto/digitalkin/module/v1/lifecycle.proto
+++ b/proto/digitalkin/module/v1/lifecycle.proto
@@ -1,0 +1,20 @@
+// Copyright 2024 DigitalKin Inc.
+//
+// Licensed under the GNU General Public License, Version 3.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.gnu.org/licenses/gpl-3.0.html
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+syntax = "proto3";
+
+package digitalkin.module.v1;
+
+import "validate/validate.proto";

--- a/proto/digitalkin/module/v1/lifecycle.proto
+++ b/proto/digitalkin/module/v1/lifecycle.proto
@@ -17,4 +17,169 @@ syntax = "proto3";
 
 package digitalkin.module.v1;
 
+import "google/protobuf/struct.proto";
 import "validate/validate.proto";
+
+// RequestType
+enum RequestType {
+    // REQUEST_TYPE_UNKNOWN is the default value
+    REQUEST_TYPE_UNKNOWN = 0;
+    // REQUEST_TYPE_SEND is send a new message in the room
+    REQUEST_TYPE_SEND = 1;
+    // REQUEST_TYPE_EXIT is Leave the room
+    REQUEST_TYPE_EXIT = 2;
+    // REQUEST_TYPE_VALIDATE is Launch the validation of requests in the room
+    REQUEST_TYPE_VALIDATE = 3;
+    // REQUEST_TYPE_DESTROY is Destroy the room
+    REQUEST_TYPE_DESTROY = 4;
+}
+
+// StartResponseType
+enum StartResponseType {
+    // START_RESPONSE_TYPE_UNKNOWN is the default value
+    START_RESPONSE_TYPE_UNKNOWN = 0;
+    // START_RESPONSE_TYPE_CONNECTION is Connection to the room
+    START_RESPONSE_TYPE_CONNECTION = 1;
+    // START_RESPONSE_TYPE_INPUT is New input data in the room
+    START_RESPONSE_TYPE_INPUT = 2;
+    // START_RESPONSE_TYPE_OUTPUT is New output data comming from a job instance
+    START_RESPONSE_TYPE_OUTPUT = 3;
+    // START_RESPONSE_TYPE_ERROR is Error message
+    START_RESPONSE_TYPE_ERROR = 4;
+}
+
+// StartModuleRequestStartModuleRequest
+//
+// Fields:
+//
+// - input: Structured input data for the module
+// - setup_id: Database ID of the setupused to start the module
+// - module_ids: List of Modules IDs to start
+// - request_type: type of the request send to the Module
+message StartModuleRequest {
+    // input: Structured input data for the module
+    google.protobuf.Struct input = 1 [(validate.rules).any = { required: true }];
+    // setup_id: Database ID of the setupused to start the module
+    string setup_id = 2 [(validate.rules).string = { min_len: 1, prefix: "setups:" }];
+    // module_ids: List of Modules IDs to start
+    repeated string module_ids = 3 [(validate.rules).repeated = { min_items: 0, items: { string: { min_len: 1, prefix: "modules:" } } }];
+    // request_type: type of the request send to the Module
+    RequestType request_type = 4 [(validate.rules).enum = { defined_only: true }];
+}
+
+// StopModuleRequest
+//
+// Fields:
+//
+// - module_id: Database ID of the Module to stop
+message StopModuleRequest {
+    // module_id: Database ID of the Module to stop
+    string module_id = 1 [(validate.rules).string = { min_len: 1, prefix: "modules:" }];
+    //? maybe add a the job id to stop and also the setup id, but it's not clear yet
+}
+
+// ConnectionResponse
+// Connections information when starting a module
+//
+// Returns:
+//
+// - message: Message with the result of the operation
+// - room_id: ID of the Room that was connected
+message ConnectionResponse {
+    // message: Message with the result of the operation
+    string message = 2 [(validate.rules).string = { min_len: 1 }];
+    // room_id: ID of the Room that was connected
+    optional string room_id = 3 [(validate.rules).string = { min_len: 1 }];
+}
+
+// InputDataResponse
+// Input data in the room when starting a module
+//
+// Returns:
+//
+// - message: Message with the result of the operation
+// - input: Structured input data for the module
+message InputDataResponse {
+    // message: Message with the result of the operation
+    string message = 2 [(validate.rules).string = { min_len: 1 }];
+    // input: Structured input data for the module
+    google.protobuf.Struct input = 1 [(validate.rules).any = { required: true }];
+}
+
+// OutputDataResponse
+// Output data returned by a job during the execution of a started module
+//
+// Returns:
+//
+// - message: Message with the result of the operation
+// - output: Structured output data a job
+// - job_id: Database ID of the job  inside the Module that was queried
+message OutputDataResponse {
+    // message: Message with the result of the operation
+    string message = 2 [(validate.rules).string = { min_len: 1 }];
+    // output: Structured output data a job
+    google.protobuf.Struct output = 1 [(validate.rules).any = { required: true }];
+    // job_id: Database ID of the job  inside the Module that was queried
+    string job_id = 3 [(validate.rules).string = { min_len: 1, prefix: "jobs:" }];
+}
+
+// ErrorResponse
+// Error message when starting a module
+//
+// Returns:
+//
+// - message: Message with the result of the operation
+// - details: Message with the result of the operation
+message ErrorResponse {
+    // message: Message with the result of the operation
+    string message = 2 [(validate.rules).string = { min_len: 1 }];
+    // details: Message with the result of the operation
+    string details = 3 [(validate.rules).string = {  }];
+}
+
+// StartModuleResponse
+//
+// Returns:
+//
+// - success: Flag to indicate if the started/stopped request was successful
+// - response_type: Type of the response
+// - connection: Response with the connection to the room
+// - input_response: Response with the input data
+// - output_response: Response with the output data
+// - error: Response with the error message
+// - module_id: Database ID of the Module that was started/stopped
+message StartModuleResponse {
+    // success: Flag to indicate if the started/stopped request was successful
+    bool success = 1;
+    // response_type: Type of the response
+    StartResponseType response_type = 2 [(validate.rules).enum = { defined_only: true }]; // Type of the response
+    // content: Response content
+    oneof content {
+        // connection: Response with the connection to the room
+        ConnectionResponse connection = 3;
+        // input_response: Response with the input data
+        InputDataResponse input_response = 4;
+        // output_response: Response with the output data
+        OutputDataResponse output_response = 5;
+        // error: Response with the error message
+        ErrorResponse error = 6;
+    }
+    // module_id: Database ID of the Module that was started/stopped
+    optional string module_id = 7 [(validate.rules).string = { prefix: "modules:" }]; // Database ID of the Module that was started/stopped
+}
+
+// StopModuleResponse
+//
+// Returns:
+//
+// - success: Flag to indicate if the started/stopped request was successful
+// - message: Message with the result of the operation
+// - module_id: Database ID of the Module that was started/stopped
+message StopModuleResponse {
+    // success: Flag to indicate if the started/stopped request was successful
+    bool success = 1;
+    // message: Message with the result of the operation
+    string message = 2 [(validate.rules).string = { min_len: 1 }];
+    // module_id: Database ID of the Module that was started/stopped
+    optional string module_id = 3 [(validate.rules).string = { prefix: "modules:" }]; // Database ID of the Module that was started/stopped
+}

--- a/proto/digitalkin/module/v1/module_service.proto
+++ b/proto/digitalkin/module/v1/module_service.proto
@@ -32,14 +32,14 @@ service ModuleService {
     // StartModule
     rpc StartModule (stream StartModuleRequest) returns (stream StartModuleResponse);
     // StopModule
-    rpc StopModule (StopModuleRequest) returns (ModuleResponse);
+    rpc StopModule (StopModuleRequest) returns (StopModuleResponse);
     // GetModuleStatus
-    rpc GetModuleStatus (GetModuleStatusRequest) returns (ModuleStatusResponse);
+    rpc GetModuleStatus (GetModuleStatusRequest) returns (GetModuleStatusResponse);
     // GetModuleInput
-    rpc GetModuleInput (GetModuleInputRequest) returns (ModuleInputResponse);
+    rpc GetModuleInput (GetModuleInputRequest) returns (GetModuleInputResponse);
     // GetModuleOutput
-    rpc GetModuleOutput (GetModuleOutputRequest) returns (ModuleOutputResponse);
+    rpc GetModuleOutput (GetModuleOutputRequest) returns (GetModuleOutputResponse);
     // GetModuleSetup
-    rpc GetModuleSetup (GetModuleSetupRequest) returns (ModuleSetupResponse);
+    rpc GetModuleSetup (GetModuleSetupRequest) returns (GetModuleSetupResponse);
 }
   

--- a/proto/digitalkin/module/v1/module_service.proto
+++ b/proto/digitalkin/module/v1/module_service.proto
@@ -1,0 +1,45 @@
+// Copyright 2024 DigitalKin Inc.
+//
+// Licensed under the GNU General Public License, Version 3.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.gnu.org/licenses/gpl-3.0.html
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package digitalkin.module.v1;
+
+import "digitalkin/module/v1/information.proto";
+import "digitalkin/module/v1/lifecycle.proto";
+import "digitalkin/module/v1/monitoring.proto";
+
+// ModuleService
+// It represents a functional unit within an agent in the multi-agent system (SMA). 
+// Modules can be of three types: Kin, Tool, and Trigger. 
+// - Kin: Represents the agent's core data architecture or "brain", such as a workflow-based model or an LLM (Large Language Model).
+// - Tool: Refers to external utilities or tools that the agent uses to perform tasks or enhance its capabilities.
+// - Trigger: Serves as the entry point for the agent, initiating processes or actions based on external inputs.
+// This service manages the lifecycle and interactions of these modules, including starting, stopping, 
+// and monitoring the module's status, as well as handling input and output operations.
+service ModuleService {
+    // StartModule
+    rpc StartModule (stream StartModuleRequest) returns (stream StartModuleResponse);
+    // StopModule
+    rpc StopModule (StopModuleRequest) returns (ModuleResponse);
+    // GetModuleStatus
+    rpc GetModuleStatus (GetModuleStatusRequest) returns (ModuleStatusResponse);
+    // GetModuleInput
+    rpc GetModuleInput (GetModuleInputRequest) returns (ModuleInputResponse);
+    // GetModuleOutput
+    rpc GetModuleOutput (GetModuleOutputRequest) returns (ModuleOutputResponse);
+    // GetModuleSetup
+    rpc GetModuleSetup (GetModuleSetupRequest) returns (ModuleSetupResponse);
+}
+  

--- a/proto/digitalkin/module/v1/monitoring.proto
+++ b/proto/digitalkin/module/v1/monitoring.proto
@@ -49,14 +49,14 @@ message GetModuleStatusRequest {
     string job_id = 1 [(validate.rules).string = { min_len: 1, prefix: "jobs:" }];
 }
 
-// ModuleStatusResponse
+// GetModuleStatusResponse
 //
 // Returns:
 //
 // - success: Flag to indicate if the status request was successful
 // - status: Status of the Module
 // - job_id: Database ID of the job inside the Module that was queried
-message ModuleStatusResponse {
+message GetModuleStatusResponse {
     // success: Flag to indicate if the status request was successful
     bool success = 1;
     // status: Status of the Module

--- a/proto/digitalkin/module/v1/monitoring.proto
+++ b/proto/digitalkin/module/v1/monitoring.proto
@@ -1,0 +1,66 @@
+// Copyright 2024 DigitalKin Inc.
+//
+// Licensed under the GNU General Public License, Version 3.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.gnu.org/licenses/gpl-3.0.html
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+syntax = "proto3";
+
+package digitalkin.module.v1;
+
+import "validate/validate.proto";
+
+// ModuleStatus
+enum ModuleStatus {
+    // MODULE_STATUS_UNKNOWN is the default value
+    MODULE_STATUS_UNKNOWN = 0;
+    // MODULE_STATUS_STARTING is the status when the module is starting
+    MODULE_STATUS_STARTING = 1;
+    // MODULE_STATUS_PROCESSING is the status when the module is processing
+    MODULE_STATUS_PROCESSING = 2;
+    // MODULE_STATUS_CANCELED is the status when the module is canceled
+    MODULE_STATUS_CANCELED = 3;
+    // MODULE_STATUS_FAILED is the status when the module is failed
+    MODULE_STATUS_FAILED = 4;
+    // MODULE_STATUS_EXPIRED is the status when the module is expired
+    MODULE_STATUS_EXPIRED = 5;
+    // MODULE_STATUS_SUCCESS is the status when the module is successful
+    MODULE_STATUS_SUCCESS = 6;
+    // MODULE_STATUS_STOPPED is the status when the module is stopped
+    MODULE_STATUS_STOPPED = 7;
+}
+
+// GetModuleStatusRequest
+//
+// Fields:
+//
+// - job_id: Database ID of the Job Module to get status
+message GetModuleStatusRequest {
+    // job_id: Database ID of the Job Module to get status
+    string job_id = 1 [(validate.rules).string = { min_len: 1, prefix: "jobs:" }];
+}
+
+// ModuleStatusResponse
+//
+// Returns:
+//
+// - success: Flag to indicate if the status request was successful
+// - status: Status of the Module
+// - job_id: Database ID of the job inside the Module that was queried
+message ModuleStatusResponse {
+    // success: Flag to indicate if the status request was successful
+    bool success = 1;
+    // status: Status of the Module
+    ModuleStatus status = 2 [(validate.rules).enum = { defined_only: true }];
+    // job_id: Database ID of the job inside the Module that was queried
+    string job_id = 3  [(validate.rules).string = { min_len: 1, prefix: "jobs:" }];
+}

--- a/proto/digitalkin/module_registry/v1/action.proto
+++ b/proto/digitalkin/module_registry/v1/action.proto
@@ -1,0 +1,72 @@
+// Copyright 2024 DigitalKin Inc.
+//
+// Licensed under the GNU General Public License, Version 3.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.gnu.org/licenses/gpl-3.0.html
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package digitalkin.module_registry.v1;
+
+import "validate/validate.proto";
+
+
+// DiscoverRequest
+//
+// Fields:
+//
+// - module_id: Id of the module
+message DiscoverRequest {
+    // module_id: Id of the module
+    string module_id = 1 [(validate.rules).string = { min_len: 1 }];
+}
+  
+// DiscoverResponse
+//
+// Returns:
+//
+// - module_type: Type of the module (trigger, tool, kin, view)
+// - address: Address used to communicate with the module
+// - port: Port used to communicate with the module
+// - status: True if the module is available
+message DiscoverResponse {
+    // module_type: Type of the module (trigger, tool, kin, view)
+    string module_type = 1 [(validate.rules).string = { in: ["trigger", "tool", "kin", "view"] }];
+    // address: Address used to communicate with the module
+    string address = 2 [(validate.rules).string = { min_len: 1 }];
+    // port: Port used to communicate with the module
+    int32 port = 3 [(validate.rules).int32 = { gte: 1, lte: 65535}];
+    // status: True if the module is available
+    bool status = 4;
+}
+  
+// UpdateStatusRequest
+//
+// Fields:
+//
+// - module_id: Id of the module
+// - status: True if the module is available
+message UpdateStatusRequest {
+    // module_id: Id of the module
+    string module_id = 1 [(validate.rules).string = { min_len: 1 }];
+    // status: True if the module is available
+    bool status = 2;
+}
+  
+// UpdateStatusResponse
+//
+// Returns:
+//
+// - success: True if the status was updated
+message UpdateStatusResponse {
+    // success: True if the status was updated
+    bool success = 1;
+}

--- a/proto/digitalkin/module_registry/v1/module_registry_service.proto
+++ b/proto/digitalkin/module_registry/v1/module_registry_service.proto
@@ -19,9 +19,6 @@ package digitalkin.module_registry.v1;
 import "digitalkin/module_registry/v1/action.proto";
 import "digitalkin/module_registry/v1/registration.proto";
 
-import "validate/validate.proto";
-
-
 // ModuleRegistryService
 // It manages the registration, discovery, and status tracking of modules within a multi-agent system (SMA).
 // In the context of SMA, this service allows autonomous agents to register their modules, making their capabilities 

--- a/proto/digitalkin/module_registry/v1/module_registry_service.proto
+++ b/proto/digitalkin/module_registry/v1/module_registry_service.proto
@@ -1,0 +1,40 @@
+// Copyright 2024 DigitalKin Inc.
+//
+// Licensed under the GNU General Public License, Version 3.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.gnu.org/licenses/gpl-3.0.html
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package digitalkin.module_registry.v1;
+
+import "digitalkin/module_registry/v1/action.proto";
+import "digitalkin/module_registry/v1/registration.proto";
+
+import "validate/validate.proto";
+
+
+// ModuleRegistryService
+// It manages the registration, discovery, and status tracking of modules within a multi-agent system (SMA).
+// In the context of SMA, this service allows autonomous agents to register their modules, making their capabilities 
+// discoverable by other agents. It facilitates dynamic collaboration by enabling agents to find and interact 
+// with available modules in real-time. Additionally, it ensures that the status of each module is kept up to date,
+// supporting the overall adaptability and coordination of the multi-agent environment.
+service ModuleRegistryService {
+    // RegisterModule
+    rpc RegisterModule(RegisterRequest) returns (RegisterResponse) {}
+    // DeregisterModule
+    rpc DeregisterModule(DeregisterRequest) returns (DeregisterResponse) {}
+    // DiscoverModule
+    rpc DiscoverModule(DiscoverRequest) returns (DiscoverResponse) {}
+    // UpdateModuleStatus
+    rpc UpdateModuleStatus(UpdateStatusRequest) returns (UpdateStatusResponse) {}
+}

--- a/proto/digitalkin/module_registry/v1/registration.proto
+++ b/proto/digitalkin/module_registry/v1/registration.proto
@@ -1,0 +1,68 @@
+// Copyright 2024 DigitalKin Inc.
+//
+// Licensed under the GNU General Public License, Version 3.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.gnu.org/licenses/gpl-3.0.html
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package digitalkin.module_registry.v1;
+
+import "validate/validate.proto";
+
+// RegisterRequest
+//
+// Fields:
+//
+// - module_id: Id of the module 
+// - module_type: Type of the module (trigger, tool, kin, view)
+// - address: Address used to communicate with the module
+// - port: Port used to communicate with the module
+message RegisterRequest {
+    // module_id: Id of the module
+    string module_id = 1 [(validate.rules).string = { min_len: 1 }];
+    // module_type: Type of the module (trigger, tool, kin, view)
+    string module_type = 2 [(validate.rules).string = { in: ["trigger", "tool", "kin", "view"] }];
+    // address: Address used to communicate with the module
+    string address = 3 [(validate.rules).string = { min_len: 1 }];
+    // port: Port used to communicate with the module
+    int32 port = 4 [(validate.rules).int32 = { gte: 1, lte: 65535}];
+}
+
+// RegisterResponse
+//
+// Returns:
+//
+// - success: True if the registration was successful
+message RegisterResponse {
+    // success: True if the registration was successful
+    bool success = 1;
+}
+
+// DeregisterRequest
+//
+// Fields:
+//
+// - module_id: Id of the module
+message DeregisterRequest {
+    // module_id: Id of the module
+    string module_id = 1;
+}
+
+// DeregisterResponse
+//
+// Returns:
+//
+// - success: True if the registration was successful
+message DeregisterResponse {
+    // success: True if the registration was successful
+    bool success = 1;
+}

--- a/proto/google/protobuf/struct.proto
+++ b/proto/google/protobuf/struct.proto
@@ -1,0 +1,95 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+syntax = "proto3";
+
+package google.protobuf;
+
+option cc_enable_arenas = true;
+option go_package = "google.golang.org/protobuf/types/known/structpb";
+option java_package = "com.google.protobuf";
+option java_outer_classname = "StructProto";
+option java_multiple_files = true;
+option objc_class_prefix = "GPB";
+option csharp_namespace = "Google.Protobuf.WellKnownTypes";
+
+// `Struct` represents a structured data value, consisting of fields
+// which map to dynamically typed values. In some languages, `Struct`
+// might be supported by a native representation. For example, in
+// scripting languages like JS a struct is represented as an
+// object. The details of that representation are described together
+// with the proto support for the language.
+//
+// The JSON representation for `Struct` is JSON object.
+message Struct {
+  // Unordered map of dynamically typed values.
+  map<string, Value> fields = 1;
+}
+
+// `Value` represents a dynamically typed value which can be either
+// null, a number, a string, a boolean, a recursive struct value, or a
+// list of values. A producer of value is expected to set one of these
+// variants. Absence of any variant indicates an error.
+//
+// The JSON representation for `Value` is JSON value.
+message Value {
+  // The kind of value.
+  oneof kind {
+    // Represents a null value.
+    NullValue null_value = 1;
+    // Represents a double value.
+    double number_value = 2;
+    // Represents a string value.
+    string string_value = 3;
+    // Represents a boolean value.
+    bool bool_value = 4;
+    // Represents a structured value.
+    Struct struct_value = 5;
+    // Represents a repeated `Value`.
+    ListValue list_value = 6;
+  }
+}
+
+// `NullValue` is a singleton enumeration to represent the null value for the
+// `Value` type union.
+//
+// The JSON representation for `NullValue` is JSON `null`.
+enum NullValue {
+  // Null value.
+  NULL_VALUE = 0;
+}
+
+// `ListValue` is a wrapper around a repeated field of values.
+//
+// The JSON representation for `ListValue` is JSON array.
+message ListValue {
+  // Repeated field of dynamically typed values.
+  repeated Value values = 1;
+}

--- a/proto/validate/validate.proto
+++ b/proto/validate/validate.proto
@@ -1,0 +1,863 @@
+syntax = "proto2";
+
+package validate;
+
+import "google/protobuf/descriptor.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/envoyproxy/protoc-gen-validate/validate";
+option java_package = "io.envoyproxy.pgv.validate";
+
+// Validation rules applied at the message level
+extend google.protobuf.MessageOptions {
+    // Disabled nullifies any validation rules for this message, including any
+    // message fields associated with it that do support validation.
+    optional bool disabled = 1071;
+    // Ignore skips generation of validation methods for this message.
+    optional bool ignored = 1072;
+}
+
+// Validation rules applied at the oneof level
+extend google.protobuf.OneofOptions {
+    // Required ensures that exactly one the field options in a oneof is set;
+    // validation fails if no fields in the oneof are set.
+    optional bool required = 1071;
+}
+
+// Validation rules applied at the field level
+extend google.protobuf.FieldOptions {
+    // Rules specify the validations to be performed on this field. By default,
+    // no validation is performed against a field.
+    optional FieldRules rules = 1071;
+}
+
+// FieldRules encapsulates the rules for each type of field. Depending on the
+// field, the correct set should be used to ensure proper validations.
+message FieldRules {
+    optional MessageRules message = 17;
+    oneof type {
+        // Scalar Field Types
+        FloatRules    float    = 1;
+        DoubleRules   double   = 2;
+        Int32Rules    int32    = 3;
+        Int64Rules    int64    = 4;
+        UInt32Rules   uint32   = 5;
+        UInt64Rules   uint64   = 6;
+        SInt32Rules   sint32   = 7;
+        SInt64Rules   sint64   = 8;
+        Fixed32Rules  fixed32  = 9;
+        Fixed64Rules  fixed64  = 10;
+        SFixed32Rules sfixed32 = 11;
+        SFixed64Rules sfixed64 = 12;
+        BoolRules     bool     = 13;
+        StringRules   string   = 14;
+        BytesRules    bytes    = 15;
+
+        // Complex Field Types
+        EnumRules     enum     = 16;
+        RepeatedRules repeated = 18;
+        MapRules      map      = 19;
+
+        // Well-Known Field Types
+        AnyRules       any       = 20;
+        DurationRules  duration  = 21;
+        TimestampRules timestamp = 22;
+    }
+}
+
+// FloatRules describes the constraints applied to `float` values
+message FloatRules {
+    // Const specifies that this field must be exactly the specified value
+    optional float const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional float lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional float lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional float gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional float gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated float ins = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated float not_ins = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
+}
+
+// DoubleRules describes the constraints applied to `double` values
+message DoubleRules {
+    // Const specifies that this field must be exactly the specified value
+    optional double const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional double lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional double lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional double gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional double gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated double ins = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated double not_ins = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
+}
+
+// Int32Rules describes the constraints applied to `int32` values
+message Int32Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional int32 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional int32 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional int32 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional int32 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional int32 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated int32 ins = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated int32 not_ins = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
+}
+
+// Int64Rules describes the constraints applied to `int64` values
+message Int64Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional int64 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional int64 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional int64 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional int64 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional int64 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated int64 ins = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated int64 not_ins = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
+}
+
+// UInt32Rules describes the constraints applied to `uint32` values
+message UInt32Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional uint32 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional uint32 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional uint32 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional uint32 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional uint32 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated uint32 ins = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated uint32 not_ins = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
+}
+
+// UInt64Rules describes the constraints applied to `uint64` values
+message UInt64Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional uint64 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional uint64 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional uint64 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional uint64 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional uint64 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated uint64 ins = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated uint64 not_ins = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
+}
+
+// SInt32Rules describes the constraints applied to `sint32` values
+message SInt32Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional sint32 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional sint32 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional sint32 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional sint32 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional sint32 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated sint32 ins = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated sint32 not_ins = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
+}
+
+// SInt64Rules describes the constraints applied to `sint64` values
+message SInt64Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional sint64 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional sint64 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional sint64 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional sint64 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional sint64 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated sint64 ins = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated sint64 not_ins = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
+}
+
+// Fixed32Rules describes the constraints applied to `fixed32` values
+message Fixed32Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional fixed32 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional fixed32 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional fixed32 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional fixed32 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional fixed32 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated fixed32 ins = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated fixed32 not_ins = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
+}
+
+// Fixed64Rules describes the constraints applied to `fixed64` values
+message Fixed64Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional fixed64 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional fixed64 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional fixed64 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional fixed64 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional fixed64 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated fixed64 ins = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated fixed64 not_ins = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
+}
+
+// SFixed32Rules describes the constraints applied to `sfixed32` values
+message SFixed32Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional sfixed32 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional sfixed32 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional sfixed32 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional sfixed32 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional sfixed32 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated sfixed32 ins = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated sfixed32 not_ins = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
+}
+
+// SFixed64Rules describes the constraints applied to `sfixed64` values
+message SFixed64Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional sfixed64 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional sfixed64 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional sfixed64 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional sfixed64 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional sfixed64 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated sfixed64 ins = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated sfixed64 not_ins = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
+}
+
+// BoolRules describes the constraints applied to `bool` values
+message BoolRules {
+    // Const specifies that this field must be exactly the specified value
+    optional bool const = 1;
+}
+
+// StringRules describe the constraints applied to `string` values
+message StringRules {
+    // Const specifies that this field must be exactly the specified value
+    optional string const = 1;
+
+    // Len specifies that this field must be the specified number of
+    // characters (Unicode code points). Note that the number of
+    // characters may differ from the number of bytes in the string.
+    optional uint64 len = 19;
+
+    // MinLen specifies that this field must be the specified number of
+    // characters (Unicode code points) at a minimum. Note that the number of
+    // characters may differ from the number of bytes in the string.
+    optional uint64 min_len = 2;
+
+    // MaxLen specifies that this field must be the specified number of
+    // characters (Unicode code points) at a maximum. Note that the number of
+    // characters may differ from the number of bytes in the string.
+    optional uint64 max_len = 3;
+
+    // LenBytes specifies that this field must be the specified number of bytes
+    optional uint64 len_bytes = 20;
+
+    // MinBytes specifies that this field must be the specified number of bytes
+    // at a minimum
+    optional uint64 min_bytes = 4;
+
+    // MaxBytes specifies that this field must be the specified number of bytes
+    // at a maximum
+    optional uint64 max_bytes = 5;
+
+    // Pattern specifies that this field must match against the specified
+    // regular expression (RE2 syntax). The included expression should elide
+    // any delimiters.
+    optional string pattern  = 6;
+
+    // Prefix specifies that this field must have the specified substring at
+    // the beginning of the string.
+    optional string prefix   = 7;
+
+    // Suffix specifies that this field must have the specified substring at
+    // the end of the string.
+    optional string suffix   = 8;
+
+    // Contains specifies that this field must have the specified substring
+    // anywhere in the string.
+    optional string contains = 9;
+
+    // NotContains specifies that this field cannot have the specified substring
+    // anywhere in the string.
+    optional string not_contains = 23;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated string ins     = 10;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated string not_ins = 11;
+
+    // WellKnown rules provide advanced constraints against common string
+    // patterns
+    oneof well_known {
+        // Email specifies that the field must be a valid email address as
+        // defined by RFC 5322
+        bool email    = 12;
+
+        // Hostname specifies that the field must be a valid hostname as
+        // defined by RFC 1034. This constraint does not support
+        // internationalized domain names (IDNs).
+        bool hostname = 13;
+
+        // Ip specifies that the field must be a valid IP (v4 or v6) address.
+        // Valid IPv6 addresses should not include surrounding square brackets.
+        bool ip       = 14;
+
+        // Ipv4 specifies that the field must be a valid IPv4 address.
+        bool ipv4     = 15;
+
+        // Ipv6 specifies that the field must be a valid IPv6 address. Valid
+        // IPv6 addresses should not include surrounding square brackets.
+        bool ipv6     = 16;
+
+        // Uri specifies that the field must be a valid, absolute URI as defined
+        // by RFC 3986
+        bool uri      = 17;
+
+        // UriRef specifies that the field must be a valid URI as defined by RFC
+        // 3986 and may be relative or absolute.
+        bool uri_ref  = 18;
+
+        // Address specifies that the field must be either a valid hostname as
+        // defined by RFC 1034 (which does not support internationalized domain
+        // names or IDNs), or it can be a valid IP (v4 or v6).
+        bool address  = 21;
+
+        // Uuid specifies that the field must be a valid UUID as defined by
+        // RFC 4122
+        bool uuid     = 22;
+
+        // WellKnownRegex specifies a common well known pattern defined as a regex.
+        KnownRegex well_known_regex = 24;
+    }
+
+    // This applies to regexes HTTP_HEADER_NAME and HTTP_HEADER_VALUE to enable
+    // strict header validation.
+    // By default, this is true, and HTTP header validations are RFC-compliant.
+    // Setting to false will enable a looser validations that only disallows
+    // \r\n\0 characters, which can be used to bypass header matching rules.
+    optional bool strict = 25 [default = true];
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 26;
+}
+
+// WellKnownRegex contain some well-known patterns.
+enum KnownRegex {
+    KNOWN_REGEX_UNKNOWN_UNSPECIFIED = 0;
+
+    // HTTP header name as defined by RFC 7230.
+    KNOWN_REGEX_HTTP_HEADER_NAME = 1;
+
+    // HTTP header value as defined by RFC 7230.
+    KNOWN_REGEX_HTTP_HEADER_VALUE = 2;
+}
+
+// BytesRules describe the constraints applied to `bytes` values
+message BytesRules {
+    // Const specifies that this field must be exactly the specified value
+    optional bytes const = 1;
+
+    // Len specifies that this field must be the specified number of bytes
+    optional uint64 len = 13;
+
+    // MinLen specifies that this field must be the specified number of bytes
+    // at a minimum
+    optional uint64 min_len = 2;
+
+    // MaxLen specifies that this field must be the specified number of bytes
+    // at a maximum
+    optional uint64 max_len = 3;
+
+    // Pattern specifies that this field must match against the specified
+    // regular expression (RE2 syntax). The included expression should elide
+    // any delimiters.
+    optional string pattern  = 4;
+
+    // Prefix specifies that this field must have the specified bytes at the
+    // beginning of the string.
+    optional bytes  prefix   = 5;
+
+    // Suffix specifies that this field must have the specified bytes at the
+    // end of the string.
+    optional bytes  suffix   = 6;
+
+    // Contains specifies that this field must have the specified bytes
+    // anywhere in the string.
+    optional bytes  contains = 7;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated bytes ins     = 8;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated bytes not_ins = 9;
+
+    // WellKnown rules provide advanced constraints against common byte
+    // patterns
+    oneof well_known {
+        // Ip specifies that the field must be a valid IP (v4 or v6) address in
+        // byte format
+        bool ip   = 10;
+
+        // Ipv4 specifies that the field must be a valid IPv4 address in byte
+        // format
+        bool ipv4 = 11;
+
+        // Ipv6 specifies that the field must be a valid IPv6 address in byte
+        // format
+        bool ipv6 = 12;
+    }
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 14;
+}
+
+// EnumRules describe the constraints applied to enum values
+message EnumRules {
+    // Const specifies that this field must be exactly the specified value
+    optional int32 const        = 1;
+
+    // DefinedOnly specifies that this field must be only one of the defined
+    // values for this enum, failing on any undefined value.
+    optional bool  defined_only = 2;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated int32 ins           = 3;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated int32 not_ins       = 4;
+}
+
+// MessageRules describe the constraints applied to embedded message values.
+// For message-type fields, validation is performed recursively.
+message MessageRules {
+    // Skip specifies that the validation rules of this field should not be
+    // evaluated
+    optional bool skip     = 1;
+
+    // Required specifies that this field must be set
+    optional bool required = 2;
+}
+
+// RepeatedRules describe the constraints applied to `repeated` values
+message RepeatedRules {
+    // MinItems specifies that this field must have the specified number of
+    // items at a minimum
+    optional uint64 min_items = 1;
+
+    // MaxItems specifies that this field must have the specified number of
+    // items at a maximum
+    optional uint64 max_items = 2;
+
+    // Unique specifies that all elements in this field must be unique. This
+    // constraint is only applicable to scalar and enum types (messages are not
+    // supported).
+    optional bool   unique    = 3;
+
+    // Items specifies the constraints to be applied to each item in the field.
+    // Repeated message fields will still execute validation against each item
+    // unless skip is specified here.
+    optional FieldRules items = 4;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 5;
+}
+
+// MapRules describe the constraints applied to `map` values
+message MapRules {
+    // MinPairs specifies that this field must have the specified number of
+    // KVs at a minimum
+    optional uint64 min_pairs = 1;
+
+    // MaxPairs specifies that this field must have the specified number of
+    // KVs at a maximum
+    optional uint64 max_pairs = 2;
+
+    // NoSparse specifies values in this field cannot be unset. This only
+    // applies to map's with message value types.
+    optional bool no_sparse = 3;
+
+    // Keys specifies the constraints to be applied to each key in the field.
+    optional FieldRules keys   = 4;
+
+    // Values specifies the constraints to be applied to the value of each key
+    // in the field. Message values will still have their validations evaluated
+    // unless skip is specified here.
+    optional FieldRules values = 5;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 6;
+}
+
+// AnyRules describe constraints applied exclusively to the
+// `google.protobuf.Any` well-known type
+message AnyRules {
+    // Required specifies that this field must be set
+    optional bool required = 1;
+
+    // In specifies that this field's `type_url` must be equal to one of the
+    // specified values.
+    repeated string ins     = 2;
+
+    // NotIn specifies that this field's `type_url` must not be equal to any of
+    // the specified values.
+    repeated string not_ins = 3;
+}
+
+// DurationRules describe the constraints applied exclusively to the
+// `google.protobuf.Duration` well-known type
+message DurationRules {
+    // Required specifies that this field must be set
+    optional bool required = 1;
+
+    // Const specifies that this field must be exactly the specified value
+    optional google.protobuf.Duration const = 2;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional google.protobuf.Duration lt = 3;
+
+    // Lt specifies that this field must be less than the specified value,
+    // inclusive
+    optional google.protobuf.Duration lte = 4;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive
+    optional google.protobuf.Duration gt = 5;
+
+    // Gte specifies that this field must be greater than the specified value,
+    // inclusive
+    optional google.protobuf.Duration gte = 6;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated google.protobuf.Duration ins = 7;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated google.protobuf.Duration not_ins = 8;
+}
+
+// TimestampRules describe the constraints applied exclusively to the
+// `google.protobuf.Timestamp` well-known type
+message TimestampRules {
+    // Required specifies that this field must be set
+    optional bool required = 1;
+
+    // Const specifies that this field must be exactly the specified value
+    optional google.protobuf.Timestamp const = 2;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional google.protobuf.Timestamp lt = 3;
+
+    // Lte specifies that this field must be less than the specified value,
+    // inclusive
+    optional google.protobuf.Timestamp lte = 4;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive
+    optional google.protobuf.Timestamp gt = 5;
+
+    // Gte specifies that this field must be greater than the specified value,
+    // inclusive
+    optional google.protobuf.Timestamp gte = 6;
+
+    // LtNow specifies that this must be less than the current time. LtNow
+    // can only be used with the Within rule.
+    optional bool lt_now  = 7;
+
+    // GtNow specifies that this must be greater than the current time. GtNow
+    // can only be used with the Within rule.
+    optional bool gt_now  = 8;
+
+    // Within specifies that this field must be within this duration of the
+    // current time. This constraint can be used alone or with the LtNow and
+    // GtNow rules.
+    optional google.protobuf.Duration within = 9;
+}

--- a/proto/validate/validate.proto
+++ b/proto/validate/validate.proto
@@ -1,13 +1,12 @@
 syntax = "proto2";
-
 package validate;
+
+option go_package = "github.com/envoyproxy/protoc-gen-validate/validate";
+option java_package = "io.envoyproxy.pgv.validate";
 
 import "google/protobuf/descriptor.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
-
-option go_package = "github.com/envoyproxy/protoc-gen-validate/validate";
-option java_package = "io.envoyproxy.pgv.validate";
 
 // Validation rules applied at the message level
 extend google.protobuf.MessageOptions {
@@ -91,11 +90,11 @@ message FloatRules {
 
     // In specifies that this field must be equal to one of the specified
     // values
-    repeated float ins = 6;
+    repeated float in = 6;
 
     // NotIn specifies that this field cannot be equal to one of the specified
     // values
-    repeated float not_ins = 7;
+    repeated float not_in = 7;
 
     // IgnoreEmpty specifies that the validation rules of this field should be
     // evaluated only if the field is not empty
@@ -127,11 +126,11 @@ message DoubleRules {
 
     // In specifies that this field must be equal to one of the specified
     // values
-    repeated double ins = 6;
+    repeated double in = 6;
 
     // NotIn specifies that this field cannot be equal to one of the specified
     // values
-    repeated double not_ins = 7;
+    repeated double not_in = 7;
 
     // IgnoreEmpty specifies that the validation rules of this field should be
     // evaluated only if the field is not empty
@@ -163,11 +162,11 @@ message Int32Rules {
 
     // In specifies that this field must be equal to one of the specified
     // values
-    repeated int32 ins = 6;
+    repeated int32 in = 6;
 
     // NotIn specifies that this field cannot be equal to one of the specified
     // values
-    repeated int32 not_ins = 7;
+    repeated int32 not_in = 7;
 
     // IgnoreEmpty specifies that the validation rules of this field should be
     // evaluated only if the field is not empty
@@ -199,11 +198,11 @@ message Int64Rules {
 
     // In specifies that this field must be equal to one of the specified
     // values
-    repeated int64 ins = 6;
+    repeated int64 in = 6;
 
     // NotIn specifies that this field cannot be equal to one of the specified
     // values
-    repeated int64 not_ins = 7;
+    repeated int64 not_in = 7;
 
     // IgnoreEmpty specifies that the validation rules of this field should be
     // evaluated only if the field is not empty
@@ -235,11 +234,11 @@ message UInt32Rules {
 
     // In specifies that this field must be equal to one of the specified
     // values
-    repeated uint32 ins = 6;
+    repeated uint32 in = 6;
 
     // NotIn specifies that this field cannot be equal to one of the specified
     // values
-    repeated uint32 not_ins = 7;
+    repeated uint32 not_in = 7;
 
     // IgnoreEmpty specifies that the validation rules of this field should be
     // evaluated only if the field is not empty
@@ -271,11 +270,11 @@ message UInt64Rules {
 
     // In specifies that this field must be equal to one of the specified
     // values
-    repeated uint64 ins = 6;
+    repeated uint64 in = 6;
 
     // NotIn specifies that this field cannot be equal to one of the specified
     // values
-    repeated uint64 not_ins = 7;
+    repeated uint64 not_in = 7;
 
     // IgnoreEmpty specifies that the validation rules of this field should be
     // evaluated only if the field is not empty
@@ -307,11 +306,11 @@ message SInt32Rules {
 
     // In specifies that this field must be equal to one of the specified
     // values
-    repeated sint32 ins = 6;
+    repeated sint32 in = 6;
 
     // NotIn specifies that this field cannot be equal to one of the specified
     // values
-    repeated sint32 not_ins = 7;
+    repeated sint32 not_in = 7;
 
     // IgnoreEmpty specifies that the validation rules of this field should be
     // evaluated only if the field is not empty
@@ -343,11 +342,11 @@ message SInt64Rules {
 
     // In specifies that this field must be equal to one of the specified
     // values
-    repeated sint64 ins = 6;
+    repeated sint64 in = 6;
 
     // NotIn specifies that this field cannot be equal to one of the specified
     // values
-    repeated sint64 not_ins = 7;
+    repeated sint64 not_in = 7;
 
     // IgnoreEmpty specifies that the validation rules of this field should be
     // evaluated only if the field is not empty
@@ -379,11 +378,11 @@ message Fixed32Rules {
 
     // In specifies that this field must be equal to one of the specified
     // values
-    repeated fixed32 ins = 6;
+    repeated fixed32 in = 6;
 
     // NotIn specifies that this field cannot be equal to one of the specified
     // values
-    repeated fixed32 not_ins = 7;
+    repeated fixed32 not_in = 7;
 
     // IgnoreEmpty specifies that the validation rules of this field should be
     // evaluated only if the field is not empty
@@ -415,11 +414,11 @@ message Fixed64Rules {
 
     // In specifies that this field must be equal to one of the specified
     // values
-    repeated fixed64 ins = 6;
+    repeated fixed64 in = 6;
 
     // NotIn specifies that this field cannot be equal to one of the specified
     // values
-    repeated fixed64 not_ins = 7;
+    repeated fixed64 not_in = 7;
 
     // IgnoreEmpty specifies that the validation rules of this field should be
     // evaluated only if the field is not empty
@@ -451,11 +450,11 @@ message SFixed32Rules {
 
     // In specifies that this field must be equal to one of the specified
     // values
-    repeated sfixed32 ins = 6;
+    repeated sfixed32 in = 6;
 
     // NotIn specifies that this field cannot be equal to one of the specified
     // values
-    repeated sfixed32 not_ins = 7;
+    repeated sfixed32 not_in = 7;
 
     // IgnoreEmpty specifies that the validation rules of this field should be
     // evaluated only if the field is not empty
@@ -487,11 +486,11 @@ message SFixed64Rules {
 
     // In specifies that this field must be equal to one of the specified
     // values
-    repeated sfixed64 ins = 6;
+    repeated sfixed64 in = 6;
 
     // NotIn specifies that this field cannot be equal to one of the specified
     // values
-    repeated sfixed64 not_ins = 7;
+    repeated sfixed64 not_in = 7;
 
     // IgnoreEmpty specifies that the validation rules of this field should be
     // evaluated only if the field is not empty
@@ -558,11 +557,11 @@ message StringRules {
 
     // In specifies that this field must be equal to one of the specified
     // values
-    repeated string ins     = 10;
+    repeated string in     = 10;
 
     // NotIn specifies that this field cannot be equal to one of the specified
     // values
-    repeated string not_ins = 11;
+    repeated string not_in = 11;
 
     // WellKnown rules provide advanced constraints against common string
     // patterns
@@ -608,27 +607,27 @@ message StringRules {
         KnownRegex well_known_regex = 24;
     }
 
-    // This applies to regexes HTTP_HEADER_NAME and HTTP_HEADER_VALUE to enable
-    // strict header validation.
-    // By default, this is true, and HTTP header validations are RFC-compliant.
-    // Setting to false will enable a looser validations that only disallows
-    // \r\n\0 characters, which can be used to bypass header matching rules.
-    optional bool strict = 25 [default = true];
+  // This applies to regexes HTTP_HEADER_NAME and HTTP_HEADER_VALUE to enable
+  // strict header validation.
+  // By default, this is true, and HTTP header validations are RFC-compliant.
+  // Setting to false will enable a looser validations that only disallows
+  // \r\n\0 characters, which can be used to bypass header matching rules.
+  optional bool strict = 25 [default = true];
 
-    // IgnoreEmpty specifies that the validation rules of this field should be
-    // evaluated only if the field is not empty
-    optional bool ignore_empty = 26;
+  // IgnoreEmpty specifies that the validation rules of this field should be
+  // evaluated only if the field is not empty
+  optional bool ignore_empty = 26;
 }
 
 // WellKnownRegex contain some well-known patterns.
 enum KnownRegex {
-    KNOWN_REGEX_UNKNOWN_UNSPECIFIED = 0;
+  UNKNOWN = 0;
 
-    // HTTP header name as defined by RFC 7230.
-    KNOWN_REGEX_HTTP_HEADER_NAME = 1;
+  // HTTP header name as defined by RFC 7230.
+  HTTP_HEADER_NAME = 1;
 
-    // HTTP header value as defined by RFC 7230.
-    KNOWN_REGEX_HTTP_HEADER_VALUE = 2;
+  // HTTP header value as defined by RFC 7230.
+  HTTP_HEADER_VALUE = 2;
 }
 
 // BytesRules describe the constraints applied to `bytes` values
@@ -666,11 +665,11 @@ message BytesRules {
 
     // In specifies that this field must be equal to one of the specified
     // values
-    repeated bytes ins     = 8;
+    repeated bytes in     = 8;
 
     // NotIn specifies that this field cannot be equal to one of the specified
     // values
-    repeated bytes not_ins = 9;
+    repeated bytes not_in = 9;
 
     // WellKnown rules provide advanced constraints against common byte
     // patterns
@@ -704,11 +703,11 @@ message EnumRules {
 
     // In specifies that this field must be equal to one of the specified
     // values
-    repeated int32 ins           = 3;
+    repeated int32 in           = 3;
 
     // NotIn specifies that this field cannot be equal to one of the specified
     // values
-    repeated int32 not_ins       = 4;
+    repeated int32 not_in       = 4;
 }
 
 // MessageRules describe the constraints applied to embedded message values.
@@ -782,11 +781,11 @@ message AnyRules {
 
     // In specifies that this field's `type_url` must be equal to one of the
     // specified values.
-    repeated string ins     = 2;
+    repeated string in     = 2;
 
     // NotIn specifies that this field's `type_url` must not be equal to any of
     // the specified values.
-    repeated string not_ins = 3;
+    repeated string not_in = 3;
 }
 
 // DurationRules describe the constraints applied exclusively to the
@@ -816,11 +815,11 @@ message DurationRules {
 
     // In specifies that this field must be equal to one of the specified
     // values
-    repeated google.protobuf.Duration ins = 7;
+    repeated google.protobuf.Duration in = 7;
 
     // NotIn specifies that this field cannot be equal to one of the specified
     // values
-    repeated google.protobuf.Duration not_ins = 8;
+    repeated google.protobuf.Duration not_in = 8;
 }
 
 // TimestampRules describe the constraints applied exclusively to the


### PR DESCRIPTION
**Description:**

Cette PR ajoute les fichiers proto gRPC nécessaires pour permettre au SDK Python de fonctionner. Les principaux fichiers proto ajoutés sont les suivants :

1. **package digitalkin.module** :
   - Ce package contient toutes les routes et schémas pour communiquer avec n'importe quel module.
   - Actuellement, seule la route `StartModule` est pleinement terminée. Les autres routes sont encore en cours de développement (Work in Progress) mais ne devraient pas subir de modifications majeures.

2. **package digitalkin.service.v1.module_registry** :
   - Ce package contient les routes permettant aux autres modules de se retrouver. Il s'agit des routes du module registry, qui joue le rôle d'annuaire des modules.

En plus des fichiers proto, cette PR ajoute également quelques bibliothèques nécessaires :
- Bibliothèques Google Struct
- Bibliothèque `validate`

**Changements inclus :**
- Ajout des fichiers proto pour `digitalkin.module.v1.*`
- Ajout des fichiers proto pour `digitalkin.service.v1.module_registry.*`
- Ajout des dépendances Google nécessaires `Struct`
- Ajout de la bibliothèque `validate`


**Remarques :**
- Les autres routes dans `digitalkin.module.v1.*` sont encore en développement et pourraient subir de légères modifications.
