### PR TITLE
Updating setup and adding module data inside storage

### DIFF
--- a/proto/buf.gen.py.yaml
+++ b/proto/buf.gen.py.yaml
@@ -1,5 +1,3 @@
-# buf.gen.py.yaml
-
 version: v1
 managed:
   enabled: true

--- a/proto/buf.py.yaml
+++ b/proto/buf.py.yaml
@@ -1,0 +1,13 @@
+# We cannot put deps inside .gen files so I create an extra file for python
+version: v1
+breaking:
+  use:
+    - FILE
+deps:
+  - buf.build/googleapis/googleapis
+  - buf.build/protocolbuffers/wellknowntypes
+lint:
+  use:
+    - DEFAULT
+    - COMMENTS
+    - FILE_LOWER_SNAKE_CASE

--- a/proto/digitalkin/module/v1/lifecycle.proto
+++ b/proto/digitalkin/module/v1/lifecycle.proto
@@ -81,14 +81,17 @@ message ConnectionRequest {
 // Fields:
 // - input: Structured input data for the module
 // - setup_id: Database ID of the setupused to start the module
+// - instance_id: ID of the instance of a module inside a setup used to retrieve a specific module setup
 // - module_ids: List of Modules IDs to start
 message InputDataRequest {
     // input: Structured input data for the module
     google.protobuf.Struct input = 1 [(buf.validate.field).required = true];
-    // setup_id: Database ID of the setupused to start the module
+    // setup_id: Database ID of the setup used to start the module
     string setup_id = 2 [(buf.validate.field).string.min_len = 1, (buf.validate.field).string.prefix = "setups:", (buf.validate.field).required = true];
+    // instance_id: ID of the instance of a module inside a setup used to retrieve a specific module setup
+    string instance_id = 3 [(buf.validate.field).string.min_len = 1, (buf.validate.field).required = true];
     // module_ids: List of Modules IDs to start
-    repeated string module_ids = 3 [(buf.validate.field).repeated.min_items = 0, (buf.validate.field).repeated.items = { string: { min_len: 1, prefix: "modules:" } }, (google.api.field_behavior) = OPTIONAL];
+    repeated string module_ids = 4 [(buf.validate.field).repeated.min_items = 0, (buf.validate.field).repeated.items = { string: { min_len: 1, prefix: "modules:" } }, (google.api.field_behavior) = OPTIONAL];
 }
 
 // StartModuleRequest

--- a/proto/digitalkin/setup/v2/setup.proto
+++ b/proto/digitalkin/setup/v2/setup.proto
@@ -25,14 +25,14 @@ import "google/protobuf/struct.proto";
 // Fields:
 //
 // - module_id: The module ID of the data.
-// - node_id: The node ID of the data.
+// - instance_id: The instance ID of the data.
 // - content: The content of the data, we cannot know what will be inside the content
 //     that's why we used Struct, to let it free but respecting a struct format.
 message Data {
     // module_id: The module ID of the data.
     string module_id = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // node_id: The node ID of the data.
-    string node_id = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+    // instance_id: The instance ID of the data.
+    string instance_id = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
     // content: The content of the data.
     google.protobuf.Struct content = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
@@ -85,27 +85,27 @@ message ReadSetupResponse {
 }
 
 
-// GetNodeSetupRequest
-// This request is used to get a node setup thanks a specific setup and node ids.
+// GetInstanceSetupRequest
+// This request is used to get an instance setup thanks a specific setup and instance ids.
 //
 // Fields:
 //
 // - setup_id: The unique identifier of the setup.
-// - node_id: The unique identifier of the setup.
-message GetNodeSetupRequest {
+// - instance_id: The unique identifier of the setup.
+message GetInstanceSetupRequest {
     // setup_id: The unique identifier of the setup.
     string setup_id = 1 [(google.api.field_behavior) = REQUIRED];
-    // node_id: The unique identifier of the node.
-    string node_id = 2 [(google.api.field_behavior) = REQUIRED];
+    // instance_id: The unique identifier of the instance.
+    string instance_id = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
-// GetNodeSetupResponse
-// This response is used to return a specific node setup from a specific setup.
+// GetInstanceSetupResponse
+// This response is used to return a specific instance setup from a specific setup.
 //
 // Returns:
 //
-// - data: The node setup.
-message GetNodeSetupResponse {
-    // data: The node setup.
+// - data: The instance setup.
+message GetInstanceSetupResponse {
+    // data: The instance setup.
     Data data = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/proto/digitalkin/setup/v2/setup_service.proto
+++ b/proto/digitalkin/setup/v2/setup_service.proto
@@ -24,10 +24,10 @@ import "google/protobuf/empty.proto";
 // SetupService
 service SetupService {
 
-    // GetNodeSetup
-    rpc GetNodeSetup(GetNodeSetupRequest) returns (GetNodeSetupResponse) {
+    // GetInstanceSetup
+    rpc GetInstanceSetup(GetInstanceSetupRequest) returns (GetInstanceSetupResponse) {
         option (google.api.http) = {
-        get: "/v2/setups/{setup_id}/nodes/{node_id}"
+        get: "/v2/setups/{setup_id}/instances/{instance_id}"
         };
     }
 

--- a/proto/digitalkin/storage/v1/data.proto
+++ b/proto/digitalkin/storage/v1/data.proto
@@ -1,0 +1,111 @@
+// Copyright 2024 DigitalKin Inc.
+//
+// Licensed under the GNU General Public License, Version 3.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.gnu.org/licenses/gpl-3.0.html
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package digitalkin.storage.v1;
+
+import "buf/validate/validate.proto";
+import "google/protobuf/struct.proto";
+
+// ModuleData
+//
+// Fields:
+// - content: The content of the module data
+// - usage: The usage of the module data
+// - module_id: The module id link to the module data
+// - data_type : The data type of the module data
+message ModuleData {
+    // id: optional id of the module data
+    optional string id = 1 [(buf.validate.field).cel = {
+        id: "optional_id_with_prefix",
+        message: "If present, id must start with 'module_data:', otherwise it can be empty",
+        expression: "this == '' || !has(this) || this.startsWith('module_data:')"
+      }];
+    // content: The content of the module data
+    google.protobuf.Struct content = 2 [(buf.validate.field).required = true];
+    // usage: The usage of the module data
+    google.protobuf.Struct usage = 3 [(buf.validate.field).required = true];
+    // module_id: The module id link to the module data
+    string module_id = 4 [(buf.validate.field).required = true, (buf.validate.field).string.prefix = "modules:"];
+    // data_type : The data type of the module data
+    string data_type = 5 [
+        (buf.validate.field).required = true,
+        (buf.validate.field).string.in = "logs",
+        (buf.validate.field).string.in = "outputs",
+        (buf.validate.field).string.in = "views",
+        (buf.validate.field).string.in = "caches"
+    ];
+}
+
+// StoreRequest
+//
+// Fields:
+// - mission_id: The mission id link to the module data
+// - items: The module data items
+message StoreRequest {
+    // mission_id: The mission id link to the module data
+    string mission_id = 1 [(buf.validate.field).required = true, (buf.validate.field).string.prefix = "missions:"];
+    // items: The module data items
+    repeated ModuleData items = 2 [(buf.validate.field).repeated.items.required = true];
+}
+
+// StoreResponse
+//
+// Fields:
+// - success: The success of the store request
+// - message: The message of the store request
+// - module_data_ids: The module data ids of the store request
+message StoreResponse {
+    // success: The success of the store request
+    bool success = 1 [(buf.validate.field).required = true];
+    // message: The message of the store request
+    string message = 2 [(buf.validate.field).required = false];
+    // module_data_ids: The module data ids of the store request
+    repeated string module_data_ids = 3 [(buf.validate.field).repeated.items = { string: { min_len: 1, prefix: "module_data:" } }];
+}
+
+
+// RetrieveRequest
+//
+// Fields:
+// - mission_id: The mission id link to the module data
+// - data_type: The module data type
+message RetrieveRequest {
+    // mission_id: The mission id link to the module data
+    string mission_id = 1 [(buf.validate.field).required = true, (buf.validate.field).string.prefix = "missions:"];
+    // data_type: The module data type
+    string data_type = 2 [
+        (buf.validate.field).required = true,
+        (buf.validate.field).string.in = "logs",
+        (buf.validate.field).string.in = "outputs",
+        (buf.validate.field).string.in = "views",
+        (buf.validate.field).string.in = "caches"
+    ];
+}
+
+// RetrieveResponse
+//
+// Fields:
+// - success: The success of the retrieve request
+// - message: The message of the retrieve request
+// - items: The module data items
+message RetrieveResponse {
+    // success: The success of the retrieve request
+    bool success = 1 [(buf.validate.field).required = true];
+    // message: The message of the retrieve request
+    string message = 2 [(buf.validate.field).required = false];
+    // items: The module data items
+    repeated ModuleData items = 3 [(buf.validate.field).repeated.items.required = true];
+}

--- a/proto/digitalkin/storage/v1/module_data_service.proto
+++ b/proto/digitalkin/storage/v1/module_data_service.proto
@@ -1,0 +1,29 @@
+// Copyright 2024 DigitalKin Inc.
+//
+// Licensed under the GNU General Public License, Version 3.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.gnu.org/licenses/gpl-3.0.html
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package digitalkin.storage.v1;
+
+import "digitalkin/storage/v1/data.proto";
+
+// ModuleDataService
+// It manages the data of the module in the storage.
+// It provides the functionality to store the data of the module.
+service ModuleDataService {
+    // StoreModuleData
+    rpc StoreModuleData(StoreRequest) returns (StoreResponse) {}
+    // RetrieveModuleData
+    rpc RetrieveModuleData(RetrieveRequest) returns (RetrieveResponse) {}
+}


### PR DESCRIPTION
fix(config): fix python buf config
feat(config): update buf gen to remove protovalide deps because it missed some proto files
feat(setup): update setup to rename node by instance and adding instance_id inside module lifecycle.proto
feat(storage): adding storage module_data
feat(module_data): update usage and content to make them google Struct
feat(module_data): adding custom constraints on id of ModuleData message