### PR TITLE
feat(setup): add SetupStatus enum with lifecycle management

### DIFF
--- a/proto/digitalkin/setup/v2/setup.proto
+++ b/proto/digitalkin/setup/v2/setup.proto
@@ -21,6 +21,29 @@ import "google/api/field_behavior.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 
+// SetupStatus
+// Represents the status of a setup.
+enum SetupStatus {
+    // DRAFT: Setup is a draft
+    DRAFT = 0;
+    // VALIDATING: Setup is being validated
+    VALIDATING = 1;
+    // READY: Setup is ready
+    READY = 2;
+    // PAUSED: Setup is paused
+    PAUSED = 4;
+    // FAILED: Setup failed
+    FAILED = 5;
+    // ARCHIVED: Setup has been archived
+    ARCHIVED = 6;
+    // NEEDS_CONFIGURATION: Setup needs configuration
+    NEEDS_CONFIGURATION = 7;
+    // CONFIGURATION_FAILED: Setup configuration failed
+    CONFIGURATION_FAILED = 8;
+    // CONFIGURATION_SUCCEEDED: Setup configuration succeeded
+    CONFIGURATION_SUCCEEDED = 9;    
+}
+
 // SetupVersion
 // Represents a version of a setup's configuration.
 //
@@ -70,6 +93,8 @@ message Setup {
     string module_id = 5 [(buf.validate.field).required = true];
     // current_setup_version: The unique identifier of the active setup version.
     optional SetupVersion current_setup_version = 6;
+    // status: The status of the setup.
+    SetupStatus status = 7 [(buf.validate.field).required = true];
 }
 
 // CreateSetupRequest
@@ -92,6 +117,8 @@ message CreateSetupRequest {
     string module_id = 4 [(buf.validate.field).required = true];
     // current_setup_version: The unique identifier of the active setup version.
     optional SetupVersion current_setup_version = 5;
+    // status: The status of the setup.
+    SetupStatus status = 6 [(buf.validate.field).required = true];
 }
 
 // CreateSetupResponse
@@ -149,6 +176,8 @@ message UpdateSetupRequest {
     string owner_id = 3;
     // current_setup_version: The unique identifier of the active setup version.
     SetupVersion current_setup_version = 4;
+    // status: The status of the setup.
+    SetupStatus status = 5 [(buf.validate.field).required = true];
 }
 
 // UpdateSetupResponse


### PR DESCRIPTION
Breaking change: Setup message now requires status field